### PR TITLE
solved fetch api url errors.  …

### DIFF
--- a/App.js
+++ b/App.js
@@ -18,8 +18,12 @@ export default class App extends React.Component {
     viewHome: true,
     viewCreate: false,
     viewMemento: false,
-    // api: '192.168.0.95/3000/story',
-    api: `http://${Constants.manifest.debuggerHost.split(':').shift().concat(':3000')}`,
+    api: 'https://brave-sloth-74.localtunnel.me', // option 1: need start localtunnel before react dev server
+    // option 2: the line below will resolve to the IP address of the computer at runtime.
+    // if the express server is also running at port 3000
+    // the app can make fetch requests to the server 
+    // as long as they are connected to the same wifi network
+    // api: `http://${Constants.manifest.debuggerHost.split(':').shift().concat(':3000')}`,
   }
 
   //Handler for getting user location

--- a/client/components/FetchTestButton.js
+++ b/client/components/FetchTestButton.js
@@ -1,6 +1,7 @@
-/* eslint-disable react/jsx-filename-extension */
+/* eslint-disable */
 import React, { Component } from 'react';
 import { Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { Constants } from 'expo';
 
 export default class FetchButton extends Component {
   constructor(props) {
@@ -11,7 +12,10 @@ export default class FetchButton extends Component {
 
   handleFetch() {
     console.log('clicked!');
-    fetch(this.props.api)
+    const { api } = this.props;
+    console.log(`attempting fetch to: ${api}`);
+
+    fetch(api)
       .then((data) => {
         console.log('response from server!');
         console.log(data);


### PR DESCRIPTION
can now hit the server from any device, on any network, provided the backend and localtunnel servers are running. Localtunnel generated url should be manually stored in App.js constructor as this.state.api before running compiling and running front end.